### PR TITLE
ENH: Bump to version 2 and give very basic promoter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,12 @@ or ping me for more information.
 
 What is possible?
 
+Custom DType with ufunc and casting
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 ```python
-from experimental_user_dtypes import float64unit as u, string_funcs; import numpy as np
+import numpy as np
+from experimental_user_dtypes import float64unit as u
 
 F = np.array([u.Quantity(70., "Fahrenheit")])
 C = F.astype(u.Float64UnitDType("Celsius"))
@@ -32,16 +36,43 @@ print(repr(C))
 # array([21.11111111111115 °C], dtype='Float64UnitDType(degC)')
 
 m = np.array([u.Quantity(5., "m")])
-m_squared = u.multiply(m, m)
+m_squared = m * m
 print(repr(m_squared))
 # array([25.0 m**2], dtype='Float64UnitDType(m**2)')
+```
+(Please don't multiple units that can't be multiply, it may crash and I have not checked
+why yet.)
+
+
+Enhanced string equality
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+```python
+import numpy as np
+from experimental_user_dtypes import string_funcs
 
 # If `string_funcs` is imported, this also works (i.e. `np.equal` with strings)
 np.equal(np.array(["string"], dtype="S"), np.array(["other_string"], dtype="S"))
 # array([False])
 ```
-(Please don't multiple units that can't be multiply, it may crash and I have not checked
-why yet.  Reductions do NOT work as of writing this, that is an open PR to NumPy.)
 
-There is also a string comparison function in `string_funcs.string_equal` that works on
-the NumPy bytes ("S" not "U") dtype.
+Customizing NumPy Promotion
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+```python
+import numpy as np
+from experimental_user_dtypes import promoter_example
+
+promoter_example.get_number_of_calls()
+# 0
+
+np.add([1., 2., 3.], [1, 2, 3])
+# array([2., 4., 6.])
+
+promoter_example.get_number_of_calls()
+# 1
+```
+Shows that it is possible implement simple ufunc "promotion" based on the
+common DType API.
+(This modifies the ufunc! In this particular case the modification should
+be completely compatible to current usage though.)

--- a/experimental_user_dtypes/dtype_api.pxd
+++ b/experimental_user_dtypes/dtype_api.pxd
@@ -46,6 +46,8 @@ cdef extern from "numpy/experimental_dtype_api.h":
 
     int PyUFunc_AddLoopFromSpec(object ufunc, PyArrayMethod_Spec *spec) except -1
 
+    int PyUFunc_AddPromoter(object ufunc, object dtypes, object promoter) except -1
+
     #
     # DType API.
     #
@@ -65,7 +67,6 @@ cdef extern from "numpy/experimental_dtype_api.h":
         pass
 
     ctypedef struct PyArrayDTypeMeta_Spec:
-        char *name
         PyTypeObject *typeobj
         int flags
         PyArrayMethod_Spec **casts
@@ -74,6 +75,12 @@ cdef extern from "numpy/experimental_dtype_api.h":
 
     int PyArrayInitDTypeMeta_FromSpec(
             PyArray_DTypeMeta *DType, PyArrayDTypeMeta_Spec *spec) except -1
+
+    PyArray_DTypeMeta *PyArray_CommonDType(
+            PyArray_DTypeMeta *, PyArray_DTypeMeta *) except NULL
+
+    PyArray_DTypeMeta *PyArray_PromoteDTypeSequence(
+            npc.intp_t, PyArray_DTypeMeta **) except NULL
 
     # Not exported in the normal NumPy pxd (should be part of the enum)
     cdef npc.NPY_CASTING NPY_CAST_IS_VIEW = <npc.NPY_CASTING>(1 << 16)

--- a/experimental_user_dtypes/float64unit.pyx
+++ b/experimental_user_dtypes/float64unit.pyx
@@ -19,7 +19,7 @@ import numpy as np
 
 __all__ = ["Quantity", "Float64UnitDType"]
 
-dtype_api.import_experimental_dtype_api(1)
+dtype_api.import_experimental_dtype_api(2)
 
 
 cdef class Quantity:
@@ -211,7 +211,6 @@ cdef int string_equal_strided_loop_unaligned(
 
 
 cdef dtype_api.PyArrayDTypeMeta_Spec spec
-spec.name = "Float64UnitDType"
 spec.typeobj = <PyTypeObject *>Quantity
 spec.flags = dtype_api.NPY_DT_PARAMETRIC
 

--- a/experimental_user_dtypes/promoter_example.pyx
+++ b/experimental_user_dtypes/promoter_example.pyx
@@ -1,0 +1,65 @@
+from cpython.object cimport PyObject
+from cpython.ref cimport Py_INCREF, Py_DECREF
+from cpython.pycapsule cimport PyCapsule_New, PyCapsule_Destructor
+
+import numpy as np
+cimport numpy as npc
+from . cimport dtype_api
+
+
+dtype_api.import_experimental_dtype_api(2)
+
+"""
+This module adds a generic promoter that is called whenver the first argument
+is a double precision float to `np.add`  (exept in some cases due to value
+based casting/promotion).
+
+NumPy might reject such a promoter in the future.  The promoter here should
+replicate (but generalize) the current NumPy behaviour.
+"""
+cdef int number_of_calls = 0
+
+
+def get_number_of_calls():
+    global number_of_calls
+    return number_of_calls
+
+
+cdef int simple_promoter(
+        PyObject *ufunc,
+        dtype_api.PyArray_DTypeMeta **op_dtypes,
+        dtype_api.PyArray_DTypeMeta **signature,
+        dtype_api.PyArray_DTypeMeta **new_dtypes) except -1:
+    """The typical, simple promoter that maps to a homogeneous signature.
+
+    Does not try to be particularly smart about the "signature":
+    """
+    # Note, should check that the ufunc has three operands
+    global number_of_calls
+    number_of_calls += 1
+
+    cdef dtype_api.PyArray_DTypeMeta *dtypes[3]
+    cdef npc.intp_t ndtypes = 0
+    for i in range(3):
+        if op_dtypes[i] != NULL:
+            dtypes[i] = op_dtypes[i]
+            ndtypes += 1
+
+    cdef dtype_api.PyArray_DTypeMeta *common = dtype_api.PyArray_PromoteDTypeSequence(
+            ndtypes, dtypes);
+
+    for i in range(3):
+        if signature[i] != NULL:
+            Py_INCREF(<object>signature[i])
+            new_dtypes[i] = signature[i]
+        else:
+            Py_INCREF(<object>common)
+            new_dtypes[i] = common
+    Py_DECREF(<object>common)
+    return 0
+
+
+cdef object capsule = PyCapsule_New(<void *>simple_promoter, "numpy._ufunc_promoter", <PyCapsule_Destructor>0)
+
+dtype_api.PyUFunc_AddPromoter(np.add, (type(np.dtype(np.float64)), None, None), capsule)
+

--- a/experimental_user_dtypes/string_funcs.pyx
+++ b/experimental_user_dtypes/string_funcs.pyx
@@ -8,7 +8,7 @@ from . cimport dtype_api
 from libc.string cimport memcmp
 
 
-dtype_api.import_experimental_dtype_api(1)
+dtype_api.import_experimental_dtype_api(2)
 
 """
 The ArrayMethod will be used also for registering ufuncs.  At this time

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,10 @@ ext_modules=[
             ["experimental_user_dtypes/string_funcs.pyx"],
             include_dirs=[np.get_include()],
             ),
+    Extension("experimental_user_dtypes.promoter_example",
+            ["experimental_user_dtypes/promoter_example.pyx"],
+            include_dirs=[np.get_include()],
+            ),
     ]
 
 


### PR DESCRIPTION
Currently requires both https://github.com/numpy/numpy/pull/20139 (for promoter to accept `None` correctly) and https://github.com/numpy/numpy/pull/20163 which export the new features as "version 2" in the experimental DType API.